### PR TITLE
Periodically re-commit previously committed offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ Changes and additions to the library will be listed here.
 
 ## Unreleased
 
+- Re-commit previously committed offsets periodically with an interval of half
+  the offset retention time, starting with the first commit (#???).
+- Expose offset retention time in the Consumer API (#316).
+
 ## v0.3.16
 
 - Fix SSL socket timeout (#283).
 - Update to the latest Datadog gem (#296).
 - Automatically detect private key type (#297).
+- Only fetch messages for subscribed topics (#309).
 
 ## v0.3.15
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ By default, offsets are committed every 10 seconds. You can increase the frequen
 
 In addition to the time based trigger it's possible to trigger checkpointing in response to _n_ messages having been processed, known as the _offset commit threshold_. This puts a bound on the number of messages that can be double-processed before the problem is detected. Setting this to 1 will cause an offset commit to take place every time a message has been processed. By default this trigger is disabled.
 
+Stale offsets are periodically purged by the broker. The broker setting `offsets.retention.minutes` controls the retention window for committed offsets, and defaults to 1 day. The length of the retention window, known as _offset retention time_, can be changed for the consumer.
+
+Previously committed offsets are re-committed, to reset the retention window, at the first commit and periodically at an interval of half the _offset retention time_.
+
 ```ruby
 consumer = kafka.consumer(
   group_id: "some-group",
@@ -514,6 +518,9 @@ consumer = kafka.consumer(
 
   # Commit offsets when 100 messages have been processed.
   offset_commit_threshold: 100,
+
+  # Increase the length of time that committed offsets are kept.
+  offset_retention_time: 7 * 60 * 60
 )
 ```
 

--- a/lib/kafka/client.rb
+++ b/lib/kafka/client.rb
@@ -243,6 +243,7 @@ module Kafka
         logger: @logger,
         commit_interval: offset_commit_interval,
         commit_threshold: offset_commit_threshold,
+        offset_retention_time: offset_retention_time
       )
 
       heartbeat = Heartbeat.new(

--- a/lib/kafka/offset_manager.rb
+++ b/lib/kafka/offset_manager.rb
@@ -1,6 +1,10 @@
 module Kafka
   class OffsetManager
-    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:)
+
+    # The default broker setting for offsets.retention.minutes is 1440.
+    DEFAULT_RETENTION_TIME = 1440 * 60
+
+    def initialize(cluster:, group:, logger:, commit_interval:, commit_threshold:, offset_retention_time:)
       @cluster = cluster
       @group = group
       @logger = logger
@@ -13,6 +17,8 @@ module Kafka
       @committed_offsets = nil
       @resolved_offsets = {}
       @last_commit = Time.now
+      @last_recommit = nil
+      @recommit_interval = (offset_retention_time || DEFAULT_RETENTION_TIME) / 2
     end
 
     def set_default_offset(topic, default_offset)
@@ -49,17 +55,15 @@ module Kafka
       end
     end
 
-    def commit_offsets
-      unless @processed_offsets.empty?
-        pretty_offsets = @processed_offsets.flat_map {|topic, partitions|
-          partitions.map {|partition, offset| "#{topic}/#{partition}:#{offset}" }
-        }.join(", ")
+    def commit_offsets(recommit = false)
+      offsets = offsets_to_commit(recommit)
+      unless offsets.empty?
+        @logger.info "Committing offsets#{recommit ? ' with recommit' : ''}: #{prettify_offsets(offsets)}"
 
-        @logger.info "Committing offsets: #{pretty_offsets}"
-
-        @group.commit_offsets(@processed_offsets)
+        @group.commit_offsets(offsets)
 
         @last_commit = Time.now
+        @last_recommit = Time.now if recommit
 
         @uncommitted_offsets = 0
         @committed_offsets = nil
@@ -67,8 +71,9 @@ module Kafka
     end
 
     def commit_offsets_if_necessary
-      if commit_timeout_reached? || commit_threshold_reached?
-        commit_offsets
+      recommit = recommit_timeout_reached?
+      if recommit || commit_timeout_reached? || commit_threshold_reached?
+        commit_offsets(recommit)
       end
     end
 
@@ -111,9 +116,37 @@ module Kafka
       Time.now - @last_commit
     end
 
+    def seconds_since_last_recommit
+      Time.now - @last_recommit
+    end
+
     def committed_offset_for(topic, partition)
       @committed_offsets ||= @group.fetch_offsets
       @committed_offsets.offset_for(topic, partition)
+    end
+
+    def offsets_to_commit(recommit = false)
+      if recommit && !@committed_offsets.nil?
+        committed_offsets_hash.merge!(@processed_offsets) do |_topic, committed, processed|
+          committed.merge!(processed)
+        end
+      else
+        @processed_offsets
+      end
+    end
+
+    def committed_offsets_hash
+      @committed_offsets.topics.each_with_object({}) do |(topic, partition_info), offsets|
+        topic_offsets = partition_info.keys.each_with_object({}) do |partition, partition_map|
+          offset = @committed_offsets.offset_for(topic, partition)
+          partition_map[partition] = offset unless offset == -1
+        end
+        offsets[topic] = topic_offsets unless topic_offsets.empty?
+      end
+    end
+
+    def recommit_timeout_reached?
+      @last_recommit.nil? || seconds_since_last_recommit >= @recommit_interval
     end
 
     def commit_timeout_reached?
@@ -122,6 +155,12 @@ module Kafka
 
     def commit_threshold_reached?
       @commit_threshold != 0 && @uncommitted_offsets >= @commit_threshold
+    end
+
+    def prettify_offsets(offsets)
+      offsets.flat_map do |topic, partitions|
+        partitions.map { |partition, offset| "#{topic}/#{partition}:#{offset}" }
+      end.join(', ')
     end
   end
 end

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -1,3 +1,5 @@
+require 'timecop'
+
 describe Kafka::OffsetManager do
   let(:cluster) { double(:cluster) }
   let(:group) { double(:group) }
@@ -8,10 +10,13 @@ describe Kafka::OffsetManager do
       cluster: cluster,
       group: group,
       logger: logger,
-      commit_interval: 0,
+      commit_interval: commit_interval,
       commit_threshold: 0,
+      offset_retention_time: offset_retention_time
     )
   }
+  let(:offset_retention_time) { nil }
+  let(:commit_interval) { 0 }
 
   before do
     allow(group).to receive(:commit_offsets)
@@ -32,6 +37,126 @@ describe Kafka::OffsetManager do
       }
 
       expect(group).to have_received(:commit_offsets).with(expected_offsets)
+    end
+  end
+
+  describe "#commit_offsets_if_necessary" do
+    let(:fetched_offsets_response) do
+      Kafka::Protocol::OffsetFetchResponse.new(topics: {
+        "greetings" => {
+          0 => partition_offset_info(-1),
+          1 => partition_offset_info(24),
+          2 => partition_offset_info(4)
+        }
+      })
+    end
+
+    before do
+      allow(group).to receive(:fetch_offsets).and_return(fetched_offsets_response)
+    end
+
+    context "at the first commit" do
+      it "re-commits previously committed offsets" do
+        fetch_committed_offsets
+        offset_manager.mark_as_processed("greetings", 1, 25)
+
+        offset_manager.commit_offsets_if_necessary
+
+        expected_offsets = {
+          "greetings" => {
+            1 => 26,
+            2 => 4
+          }
+        }
+
+        expect(group).to have_received(:commit_offsets).with(expected_offsets)
+      end
+    end
+
+    context "commit intervals" do
+      let(:commit_interval) { 10 }
+      let(:offset_retention_time) { 300 }
+      let(:commits) { [] }
+
+      before do
+        allow(group).to receive(:commit_offsets) do |offsets|
+          commits << offsets
+        end
+        Timecop.freeze(Time.now)
+        # initial commit
+        offset_manager.mark_as_processed("greetings", 0, 0)
+        offset_manager.commit_offsets_if_necessary
+        expect(commits.size).to eq(1)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      context "before the commit timeout" do
+        before do
+          Timecop.travel(commit_interval - 1)
+        end
+
+        it "does not commit processed offsets to the group" do
+          expect do
+            offset_manager.mark_as_processed("greetings", 0, 1)
+            offset_manager.commit_offsets_if_necessary
+          end.not_to change(commits, :size)
+        end
+      end
+
+      context "after the commit timeout" do
+        before do
+          Timecop.travel(commit_interval + 1)
+          fetch_committed_offsets
+        end
+
+        it "commits processed offsets without recommitting previously committed offsets" do
+          expect do
+            offset_manager.mark_as_processed("greetings", 0, 1)
+            offset_manager.commit_offsets_if_necessary
+          end.to change(commits, :size).by(1)
+
+          expected_offsets = {
+            "greetings" => { 0 => 2 }
+          }
+
+          expect(commits.last).to eq(expected_offsets)
+        end
+      end
+
+      context "after the recommit timeout" do
+        before do
+          Timecop.travel(offset_retention_time / 2 + 1)
+          fetch_committed_offsets
+        end
+
+        it "commits processed offsets and recommits previously committed offsets" do
+          expect do
+            offset_manager.mark_as_processed("greetings", 0, 1)
+            offset_manager.commit_offsets_if_necessary
+          end.to change(commits, :size).by(1)
+
+          expected_offsets = {
+            "greetings" => {
+              0 => 2,
+              1 => 24,
+              2 => 4
+            }
+          }
+
+          expect(commits.last).to eq(expected_offsets)
+        end
+      end
+    end
+
+    def fetch_committed_offsets
+      offset_manager.next_offset_for("greetings", 1)
+    end
+
+    def partition_offset_info(offset)
+      Kafka::Protocol::OffsetFetchResponse::PartitionOffsetInfo.new(offset: offset, metadata: nil, error_code: 0)
     end
   end
 

--- a/spec/offset_manager_spec.rb
+++ b/spec/offset_manager_spec.rb
@@ -84,6 +84,7 @@ describe Kafka::OffsetManager do
         end
         Timecop.freeze(Time.now)
         # initial commit
+        fetch_committed_offsets
         offset_manager.mark_as_processed("greetings", 0, 0)
         offset_manager.commit_offsets_if_necessary
         expect(commits.size).to eq(1)
@@ -109,7 +110,6 @@ describe Kafka::OffsetManager do
       context "after the commit timeout" do
         before do
           Timecop.travel(commit_interval + 1)
-          fetch_committed_offsets
         end
 
         it "commits processed offsets without recommitting previously committed offsets" do
@@ -129,7 +129,6 @@ describe Kafka::OffsetManager do
       context "after the recommit timeout" do
         before do
           Timecop.travel(offset_retention_time / 2 + 1)
-          fetch_committed_offsets
         end
 
         it "commits processed offsets and recommits previously committed offsets" do


### PR DESCRIPTION
The committed offsets held by the offset manager are re-committed, along with the processed offsets, at the first commit and periodically at an interval of half the `offset_retention_time`.

Looking for feedback before submitting upstream.

Prime: @jturkel 